### PR TITLE
Fix first version 0.9.0 at 39a8c4b (working with ecmc 6.0.1).

### DIFF
--- a/configure/CONFIG_MODULE
+++ b/configure/CONFIG_MODULE
@@ -1,9 +1,9 @@
 #
 EPICS_MODULE_NAME:=ecmccfg
 
-EPICS_MODULE_TAG:=master
+EPICS_MODULE_TAG:=39a8c4b
 #
-E3_MODULE_VERSION:=master
+E3_MODULE_VERSION:=0.9.0
 #
 #
 # In most case, we don't need to touch the following variables.


### PR DESCRIPTION
Version 1.0.0 will be released later, after sync with PSI.